### PR TITLE
Make it Python 3 compatibile

### DIFF
--- a/graphsim/iter/ASCOS.py
+++ b/graphsim/iter/ASCOS.py
@@ -87,7 +87,7 @@ def ascos(G, c=0.9, max_iter=100, is_weighted=False, remove_neighbors=False, rem
         sim_old = copy.deepcopy(sim)
         for i in range(n):
             if dump_process:
-                print iter_ctr, ':', i, '/', n
+                print(iter_ctr, ':', i, '/', n)
             for j in range(n):
                 if not is_weighted:
                     if i == j:

--- a/graphsim/iter/HITS.py
+++ b/graphsim/iter/HITS.py
@@ -21,7 +21,7 @@ def normalized(a, axis=0, order=2):
     return a / np.expand_dims(l2, axis)
 
 
-@params(G=nx.DiGraph, max_iter=long, eps=float)
+@params(G=nx.DiGraph, max_iter=int, eps=float)
 def hits(G, max_iter=100, eps=1e-4):
     """HITS algorithm:
     calculate the hub and authority scores for nodes in a graph.
@@ -58,4 +58,4 @@ def hits(G, max_iter=100, eps=1e-4):
 if __name__ == '__main__':
     G = nx.DiGraph()
     G.add_edges_from([(1,4), (1,5), (1,6), (2,5), (2,7), (3,4), (3,5), (3,6), (3,7)])
-    print hits(G)
+    print(hits(G))

--- a/graphsim/iter/SimRank.py
+++ b/graphsim/iter/SimRank.py
@@ -18,7 +18,7 @@ __email__ = "chen_xm@sjtu.edu.cn"
 __all__ = [ 'simrank', 'simrank_bipartite' ]
 
 
-@params(G=nx.Graph, r=float, max_iter=long, eps=float)
+@params(G=nx.Graph, r=float, max_iter=int, eps=float)
 def simrank(G, r=0.8, max_iter=100, eps=1e-4):
     """ Algorithm of G. Jeh and J. Widom. SimRank: A Measure
     of Structural-Context Similarity. In KDD'02.
@@ -68,7 +68,7 @@ def simrank(G, r=0.8, max_iter=100, eps=1e-4):
     return sim
 
 
-@params(G=nx.DiGraph, r=float, max_iter=long, eps=float)
+@params(G=nx.DiGraph, r=float, max_iter=int, eps=float)
 def simrank_bipartite(G, r=0.8, max_iter=100, eps=1e-4):
     """ A bipartite version in the paper.
     """

--- a/graphsim/iter/TACSim.py
+++ b/graphsim/iter/TACSim.py
@@ -239,7 +239,7 @@ if __name__ == '__main__':
     G2.node[1]['weight'] = 3
     G2.node[2]['weight'] = 1
 
-    print tacsim(G1, G2)
-    print tacsim(G1)
+    print(tacsim(G1, G2))
+    print(tacsim(G1))
 
-    print tacsim_combined(G1, G2)
+    print(tacsim_combined(G1, G2))

--- a/graphsim/iter/TACSim_in_C.py
+++ b/graphsim/iter/TACSim_in_C.py
@@ -205,9 +205,9 @@ if __name__ == '__main__':
     G2.node[1]['weight'] = 3
     G2.node[2]['weight'] = 1
 
-    print tacsim_in_C(G1, G2)
+    print(tacsim_in_C(G1, G2))
 
-    print tacsim_in_C(G1)
+    print(tacsim_in_C(G1))
 
-    print tacsim_combined_in_C(G1, G2)
+    print(tacsim_combined_in_C(G1, G2))
 


### PR DESCRIPTION
As I would like to use this package with Python 3 I made a few modifications.
First, I added parenthesis to the print keywords as print is a function in Python 3.x, and second, I had to change the long types in the decorators because there is no long type int Python 3 anymore, int should be used instead.

Now, every example runs with both Python 2(.7.13) and Python 3(.6.0), but without tests I could not validate the result values.